### PR TITLE
Aggressive merging of dumps from different processes

### DIFF
--- a/bin/stackprof
+++ b/bin/stackprof
@@ -38,16 +38,17 @@ end
 parser.parse!
 parser.abort(parser.help) if ARGV.empty?
 
-reports = []
+dumps = []
 while ARGV.size > 0
   begin
     file = ARGV.pop
-    reports << StackProf::Report.new(Marshal.load(IO.binread(file)))
+    dumps << Marshal.load(IO.binread(file))
   rescue TypeError => e
     STDERR.puts "** error parsing #{file}: #{e.inspect}"
   end
 end
-report = reports.inject(:+)
+dump = StackProf::DumpMerger.merge_raw_dumps(dumps)
+report = StackProf::Report.new(dump)
 
 default_options = {
   :format => :text,

--- a/lib/stackprof.rb
+++ b/lib/stackprof.rb
@@ -1,4 +1,5 @@
 require "stackprof/stackprof"
 
 StackProf.autoload :Report, "stackprof/report.rb"
+StackProf.autoload :DumpMerger, "stackprof/dump_merger.rb"
 StackProf.autoload :Middleware, "stackprof/middleware.rb"

--- a/lib/stackprof/dump_reader.rb
+++ b/lib/stackprof/dump_reader.rb
@@ -30,6 +30,10 @@ module StackProf
       raise ArgumentError, "cannot combine different versions of dumps" if reports.map {|r| r[:version]}.uniq.size > 1
       raise ArgumentError, "cannot combine different modes" if reports.map {|r| r[:mode]}.uniq.size > 1
 
+      concatenated_raw = reports.map {|r| r[:raw]}.concat.flatten.compact
+      # raw = merge_duplicate_raw_segments(concatenated_raw)
+      raw = concatenated_raw
+
       data = {
         version: reports[0][:version],
         mode: reports[0][:mode],
@@ -38,11 +42,41 @@ module StackProf
         gc_samples: reports.map {|r| r[:gc_samples]}.sum,
         missed_samples: reports.map {|r| r[:missed_samples]}.sum,
         frames: reports.map {|r| r[:frames]}.inject(&:merge),
-        raw: reports.map {|r| r[:raw]}.concat.flatten.compact,
-        raw_timestamp_deltas: reports.map {|r| r[:raw_timestamp_deltas]}.concat.flatten.compact,
+        raw: raw,
+        raw_timestamp_deltas: reports.map {|r| r[:raw_timestamp_deltas]}.concat.flatten.compact,  # is this correct?
       }
 
       data
+    end
+
+    def merge_duplicate_raw_segments(raw_array)
+      stacks = {}
+      while len = raw_array.shift
+        callstack = raw_array.slice!(0, len)
+        appearance_count = raw_array.shift
+        hashcode = callstack.hash
+
+        if !stacks.key?(hashcode)
+          stacks[hashcode] = {
+            callstack: callstack,
+            appearance_count: appearance_count
+          }
+        else
+          # merge
+          stacks[hashcode][:appearance_count] += appearance_count
+        end
+      end
+
+      # flatten to the original format
+      merged_raw = stacks.map do |hashcode, stack|
+        r = []
+        r << stack[:callstack].size
+        r.append(stack[:callstack])
+        r << stack[:appearance_count]
+        r
+      end.flatten
+
+      merged_raw
     end
   end
 end

--- a/lib/stackprof/dump_reader.rb
+++ b/lib/stackprof/dump_reader.rb
@@ -1,0 +1,48 @@
+require 'digest/md5'
+
+module StackProf
+  class DumpReader
+    class << self
+      def read(path)
+        self.new.batch_read([path])
+      end
+
+      def batch_read(paths)
+        self.new.batch_read(paths)
+      end
+    end
+
+    def batch_read(paths)
+      raw_reports = paths.map do |path|
+        begin
+          Marshal.load(IO.binread(path))
+        rescue TypeError => e
+          STDERR.puts "** error parsing #{file}: #{e.inspect}"
+        end
+      end
+
+      raw_merged = merge_raw_reports(raw_reports)
+      StackProf::Report.new(raw_merged)
+    end
+
+    def merge_raw_reports(reports, aggressive: false)
+      # sanity checks
+      raise ArgumentError, "cannot combine different versions of dumps" if reports.map {|r| r[:version]}.uniq.size > 1
+      raise ArgumentError, "cannot combine different modes" if reports.map {|r| r[:mode]}.uniq.size > 1
+
+      data = {
+        version: reports[0][:version],
+        mode: reports[0][:mode],
+        interval: reports[0][:interval],
+        samples: reports.map {|r| r[:samples]}.sum,
+        gc_samples: reports.map {|r| r[:gc_samples]}.sum,
+        missed_samples: reports.map {|r| r[:missed_samples]}.sum,
+        frames: reports.map {|r| r[:frames]}.inject(&:merge),
+        raw: reports.map {|r| r[:raw]}.concat.flatten.compact,
+        raw_timestamp_deltas: reports.map {|r| r[:raw_timestamp_deltas]}.concat.flatten.compact,
+      }
+
+      data
+    end
+  end
+end

--- a/lib/stackprof/report.rb
+++ b/lib/stackprof/report.rb
@@ -139,7 +139,7 @@ module StackProf
       end
     end
 
-    def +(other)
+    def merge(other)
       raise ArgumentError, "cannot combine #{other.class}" unless self.class == other.class
       raise ArgumentError, "cannot combine #{modeline} with #{other.modeline}" unless modeline == other.modeline
       raise ArgumentError, "cannot combine v#{version} with v#{other.version}" unless version == other.version
@@ -184,6 +184,8 @@ module StackProf
 
       self.class.new(data)
     end
+
+    alias_method :+, :merge
 
     private
     def root_frames


### PR DESCRIPTION
This pull request adds implementation of StackProf::DumpMerger, which handles merging of dumps better than StackProf::DumpMerger#+.
This implementation is capable of merging from different processes, squashing ISeq pointers which share method names and positions in files.